### PR TITLE
🫡 [just] fix branch name in GHA

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,7 +7,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
How did we overlook `master` in there before?  (The repo we copied and pasted from has not modernized this yet.)

Since we're on a branch there's no way to verify the non-branch aspect of the GHA without merging and hoping.