### PR TITLE
🥥 [gha] get ARM and Intel for MacOS

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,9 +18,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          - macos-13
           - macos-latest
           - windows-latest
+          - ubuntu-latest
+          - debian-latest
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,6 @@ jobs:
           - macos-latest
           - windows-latest
           - ubuntu-latest
-          - debian-latest
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
* GHA Linux is always Ubuntu, sigh.
* `macos-latest` is always ARM, yay.
* `macos-13` gets us Intel for Mac so we can say we did multi-arch, just not how we expected
