### PR TITLE
🕰 [gha] retire macos-13

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -13,12 +13,13 @@ defaults:
   run:
     shell: bash
 
+# in 2025 macos-latest is macos-15 and macos-13 is about to retire
 jobs:
   test:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-14
           - macos-latest
           - windows-latest
           - ubuntu-latest


### PR DESCRIPTION
## Context

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

> The macOS 13 runner image will be retired by December 4th, 2025.

They're also deprecating x86_64 for macos, but that doesn't look like it will break our GHA's.

## Done:

- 🕰 [gha] retire macos-13

## Verify

Test still passed on this PR.

(Automated in `justfile`.)
